### PR TITLE
Fix decimal point problem with different locales

### DIFF
--- a/app/src/main/java/com/mediamonks/googleflip/pages/game/physics/control/WorldController.java
+++ b/app/src/main/java/com/mediamonks/googleflip/pages/game/physics/control/WorldController.java
@@ -334,7 +334,7 @@ public class WorldController extends Entity {
             _timeText = new Text(_width, _height - barHeight / 2, smallWhiteFont, "00.0", _engine.getVertexBufferObjectManager());
             _timeText.setOffsetCenterX(0);
             _timeText.setX(_width - (_timeText.getWidth() + (15 * _density)));
-            _timeText.setText("0.0");
+            _timeText.setText(String.format("%.01f", 0.0f));
 
             attachChild(_timeText);
         }


### PR DESCRIPTION
In Spanish the decimal _point_ is a comma. It was _strange_ that the clock started with `0.0` but then it said `0,1`, `0,2`...
